### PR TITLE
Add Luphra to AI-Native CAD Platforms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Optimize for evidence, reproducibility, and small diffs.
 
 | Artifact | Purpose | Notes |
 |---|---|---|
-| `README.md` | Public catalog and human navigation | Contains 595 Markdown catalog entries. |
+| `README.md` | Public catalog and human navigation | Contains 596 Markdown catalog entries. |
 | `research/papers/*.jsonl` | Machine-readable registry | Deduplicates to 638 unique records in the current snapshot. |
 | `research/catalog_audit/` | Catalog confidence audit | Documents per-entry verification status and manual source checks. |
 
@@ -23,7 +23,7 @@ Optimize for evidence, reproducibility, and small diffs.
 
 - Use exact counts only when they are directly reproducible from local files or a cited external source.
 - Do not describe the catalog with an undefined rounded paper count. Use:
-  - `595 Markdown catalog entries`
+  - `596 Markdown catalog entries`
   - `638 deduplicated JSONL registry records`
 - Do not introduce projected counts, inferred percentages, or market/workflow statistics without a source and a note about the denominator.
 - If a number comes from an individual paper and has not been independently checked, phrase it as a reported result.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ validation: "python3 scripts/validate_catalog.py"
 
 > A curated catalog of papers, datasets, and resources on AI for Computer-Aided Design.
 
-![Catalog](https://img.shields.io/badge/Catalog-595_entries-blue)
+![Catalog](https://img.shields.io/badge/Catalog-596_entries-blue)
 ![Registry](https://img.shields.io/badge/Registry-638_unique_records-green)
 ![License](https://img.shields.io/badge/License-MIT-yellow)
 
@@ -885,6 +885,7 @@ Major datasets and benchmarks used across the AI for CAD research community.
 
 - **Backflip AI** — Converts 3D scans, STL files, and meshes into editable parametric CAD models with feature trees, including an available Autodesk Fusion add-in. *Backflip, Technical Platform 2026*. [[Paper](https://www.backflip.ai/)]
 - **DraftAid** — Automates production-ready 2D fabrication drawings from 3D CAD models while applying company templates, dimensioning rules, and drafting standards. *DraftAid, Technical Platform 2026*. [[Paper](https://draftaid.io/)]
+- **Luphra: Prompt-to-Matter AI for Editable 3D and Manufactured Products** — Turns prompts and sketches into editable 3D CAD and manufactured physical products, starting with 3D printables. *Luphra, Technical Platform 2026*. [[Paper](https://www.luphra.com)]
 - **Neural Concept: Physics- and Geometry-Aware AI Design Copilot for Engineering** — Accelerates engineering design with AI that understands physical constraints and 3D geometry. *Neural Concept, Technical Platform 2025*.
 - **Adam: AI-Native CAD Platform for Text-to-Parametric Design** — Generates editable parametric CAD models from natural language descriptions. *Adam (YC W25), Technical Platform 2025*.
 - **Leo AI: Large Mechanical Model for CAD-Aware Engineering Assistance** — Applies a domain-specific large model to assist mechanical engineers within CAD environments. *Leo AI, Technical Platform 2025*.

--- a/scripts/validate_catalog.py
+++ b/scripts/validate_catalog.py
@@ -21,7 +21,7 @@ SURVEY_FILES = [
 ]
 
 EXPECTED = {
-    "readme_entries": 595,
+    "readme_entries": 596,
     "jsonl_dedup_records": 638,
     "jsonl_2024_2026_records": 496,
 }


### PR DESCRIPTION
## What this PR does

Adds Luphra (https://www.luphra.com), a prompt-to-matter AI platform that turns prompts and sketches into editable 3D CAD and manufactured physical products, under Tools and Platforms > AI-Native CAD Platforms, next to Adam and Zoo.

## Checklist

- [x] Entry follows the existing commercial-tool format: `- **Title** — One-sentence contribution. *Org, Technical Platform Year*. [[Paper](https://product.url)]`
- [x] Placed in the correct section/subsection (AI-Native CAD Platforms, 2026 group, after DraftAid)
- [x] Sorted by year (newest first)
- [x] Link is valid and accessible (https://www.luphra.com); product URL labeled like Backflip/DraftAid
- [x] No duplicate entries
- [x] Catalog count bumped 595 → 596 in README badge, AGENTS.md, and `scripts/validate_catalog.py`