### PR TITLE
Update AI4CAD catalog for 2026-08-31

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Optimize for evidence, reproducibility, and small diffs.
 
 | Artifact | Purpose | Notes |
 |---|---|---|
-| `README.md` | Public catalog and human navigation | Contains 595 Markdown catalog entries. |
+| `README.md` | Public catalog and human navigation | Contains 598 Markdown catalog entries. |
 | `research/papers/*.jsonl` | Machine-readable registry | Deduplicates to 638 unique records in the current snapshot. |
 | `research/catalog_audit/` | Catalog confidence audit | Documents per-entry verification status and manual source checks. |
 
@@ -23,7 +23,7 @@ Optimize for evidence, reproducibility, and small diffs.
 
 - Use exact counts only when they are directly reproducible from local files or a cited external source.
 - Do not describe the catalog with an undefined rounded paper count. Use:
-  - `595 Markdown catalog entries`
+  - `598 Markdown catalog entries`
   - `638 deduplicated JSONL registry records`
 - Do not introduce projected counts, inferred percentages, or market/workflow statistics without a source and a note about the denominator.
 - If a number comes from an individual paper and has not been independently checked, phrase it as a reported result.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!--
 repo: awesome-ai4cad
 scope: AI methods for Computer-Aided Design (2018-2026)
-catalog_entries: 595
+catalog_entries: 598
 deduplicated_registry_records: 638
 registry_records_2024_2026: 496
 entry_format: "Markdown list item with title, authors, venue/year, and a source link; arXiv links use the identifier as label"
@@ -12,7 +12,7 @@ validation: "python3 scripts/validate_catalog.py"
 
 > A curated catalog of papers, datasets, and resources on AI for Computer-Aided Design.
 
-![Catalog](https://img.shields.io/badge/Catalog-595_entries-blue)
+![Catalog](https://img.shields.io/badge/Catalog-598_entries-blue)
 ![Registry](https://img.shields.io/badge/Registry-638_unique_records-green)
 ![License](https://img.shields.io/badge/License-MIT-yellow)
 
@@ -731,8 +731,8 @@ Design for manufacturing, additive manufacturing, assembly planning, and CAD/CAM
 - **Deep Neural Implicit Representation of Accessibility for Multi-Axis Manufacturing** — Encodes tool accessibility as a deep implicit representation for multi-axis machining planning. *Authors, Computer-Aided Design 2024*. [[2409.02115](https://arxiv.org/abs/2409.02115)]
 - **Automatic Feature Recognition and Dimensional Attributes Extraction From CAD Models for Hybrid Additive-Subtractive Manufacturing** — Extracts manufacturing features and dimensions from CAD models for hybrid manufacturing workflows. *Authors, arXiv preprint 2024*. [[2408.06891](https://arxiv.org/abs/2408.06891)]
 - **BrepMFR: Enhancing Machining Feature Recognition in B-rep Models through Deep Learning and Domain Adaptation** — Combines deep learning with domain adaptation to recognize machining features in B-rep CAD models. *Zhang et al., Computer Aided Geometric Design 2024*. [[Paper](https://doi.org/10.1016/j.cagd.2024.102318)]
-- **BRepGAT: Graph Neural Network to Segment Machining Feature Faces in a B-rep Model** — Uses graph attention networks to segment machining feature faces directly from B-rep models. *Authors, ResearchGate / Journal 2024*. [[Paper](https://www.researchgate.net)]
-- **Real-Time Tool-Path Planning Using Deep Learning for Subtractive Manufacturing** — Proposes a deep learning approach for real-time tool-path planning in subtractive manufacturing. *Authors, ResearchGate / Journal 2024*. [[Paper](https://www.researchgate.net)]
+- **BRepGAT: Graph Neural Network to Segment Machining Feature Faces in a B-rep Model** — Uses graph attention networks to segment machining feature faces directly from B-rep models. *Jinwon Lee, Changmo Yeo, Sang-Uk Cheon et al., Journal of Computational Design and Engineering 2023*. [[Paper](https://doi.org/10.1093/jcde/qwad106)]
+- **Real-Time Tool-Path Planning Using Deep Learning for Subtractive Manufacturing** — Proposes a deep learning approach for real-time tool-path planning in subtractive manufacturing. *Yi-Fei Feng, Hong-Yu Ma, Li-Yong Shen et al., IEEE Transactions on Industrial Informatics 2024*. [[Paper](https://doi.org/10.1109/TII.2023.3342474)]
 - **Large Language Models for Manufacturing** — Explores applications of large language models to manufacturing processes and decision-making. *Yixin Tian et al., arXiv preprint 2024*. [[2410.21418](https://arxiv.org/abs/2410.21418)]
 - **Co-Optimization of Tool Orientations, Kinematic Redundancy, and Waypoint Timing for Robot-Assisted Manufacturing** — Jointly optimizes tool orientations, redundancy resolution, and timing for robotic machining paths. *Authors, arXiv preprint 2024*. [[2409.13448](https://arxiv.org/abs/2409.13448)]
 - **Learning-Based Toolpath Planner on Diverse Graphs for 3D Printing** — Learns toolpath planning strategies over graph representations for additive manufacturing. *Yuming Huang et al., arXiv preprint 2024*. [[2408.09198](https://arxiv.org/abs/2408.09198)]
@@ -841,6 +841,8 @@ Major datasets and benchmarks used across the AI for CAD research community.
 
 ### Benchmark Challenges
 
+- **ParamCAD-AgentBench** — Releases an executable long-horizon benchmark with 2,409 kernel-validated parametric CAD models and 4,818 paired language-agent tasks across core and challenge splits. *ParamCAD-AgentBench contributors, GitHub 2026*. [[Benchmark](https://github.com/Fasuiker/ParamCAD-AgentBench)]
+- **ParaEval** — Evaluates executed Rhino/Grasshopper parametric designs across runtime validity, measured geometry, visual intent, and headless structural solvability with explicit abstention for unmeasurable layers. *Magnus Huber / Technical University of Munich, GitHub 2026*. [[Benchmark](https://github.com/magnush01/ParaEval)]
 - **PhysicsBench: A Unified Leaderboard for Generative and Predictive Models in Engineering Design and Simulation** — Standardizes evaluation of geometry generation and physical prediction across CAD, CFD, and FEA tasks and data scales. *Sang Won Lee, Hyogu Jeong, Namwoo Kang, arXiv 2026*. [[2608.24056](https://arxiv.org/abs/2608.24056)] [[Code](https://github.com/Narnialabs/leaderboard)]
 - **CADEngBench: It Looks Like CAD, but Does It Work? Evaluating Parametric Design, Assembly Reasoning, and Physics Simulation** — Tests CAD systems through parametric perturbations, functional edits, DFM checks, matched FEA, and joint grounding. *Harmanjot Singh, Abhra Dubey, Jorge Alejandro Amador Herrera, arXiv 2026*. [[2608.09296](https://arxiv.org/abs/2608.09296)]
 - **OmniMech: All-in-one Multimodal Mechanical Benchmark for 3D Reconstruction** — Pairs dimensioned engineering drawings with native CAD, STEP, B-rep, renderings, and annotations for executable reconstruction and agentic reasoning. *Taiting Lu, Runze Liu, Ziwei Dong et al., arXiv 2026*. [[2608.05539](https://arxiv.org/abs/2608.05539)]
@@ -894,6 +896,7 @@ Major datasets and benchmarks used across the AI for CAD research community.
 
 ### Open-Source Tools and Frameworks
 
+- **build123d-mcp** — Exposes iterative build123d/OpenCascade modeling, rendering, inspection, repair, measurement, and STEP/STL/SVG/DXF export to AI clients through MCP. *Paul Fremantle, GitHub 2026*. [[Project](https://github.com/pzfreo/build123d-mcp)]
 - **MAC (Multi-Agent CAD)** — Implements a four-agent build123d pipeline with structured state transfer, executable geometry checks, repair loops, and a reproducible feature benchmark. *Tsinghua University IEI Lab, GitHub 2026*. [[Paper](https://github.com/Pan-Chera/Multi-Agent-CAD)]
 - **Text23D Mechanical** — Provides a local conversational CAD workspace with CadQuery and FreeCAD backends, editable artifacts, provider adapters, and streamed agent execution. *Text23D, GitHub 2026*. [[Paper](https://github.com/zqf3229294/Text23D)]
 - **Sphaire** — Runs AI-assisted parametric CAD in the browser using OpenCascade/Replicad, inspectable construction code, geometry validation, DFM checks, and local or hosted model providers. *Sphaire contributors, GitHub 2026*. [[Paper](https://github.com/PranavChahal/sphaire-web)]
@@ -972,7 +975,7 @@ This repository intentionally separates three denominators:
 
 | Denominator | Current Count | Source |
 |---|---:|---|
-| Markdown catalog entries | 595 | `README.md` list entries |
+| Markdown catalog entries | 598 | `README.md` list entries |
 | Deduplicated registry records | 638 | `research/papers/*.jsonl` |
 | Registry records dated 2024-2026 | 496 | `research/papers/*.jsonl` |
 
@@ -981,7 +984,7 @@ Use these terms explicitly when citing counts. Do not collapse them into an unde
 For the latest full catalog-entry confidence review, see
 [catalog_entry_audit_summary_2026-05-30.md](research/catalog_audit/catalog_entry_audit_summary_2026-05-30.md).
 The subsequent incremental review is documented in
-[catalog_increment_review_2026-08-27.md](research/catalog_audit/catalog_increment_review_2026-08-27.md).
+[catalog_increment_review_2026-08-31.md](research/catalog_audit/catalog_increment_review_2026-08-31.md).
 
 ---
 

--- a/research/catalog_audit/catalog_increment_review_2026-08-31.md
+++ b/research/catalog_audit/catalog_increment_review_2026-08-31.md
@@ -1,0 +1,86 @@
+# Catalog Increment Review
+
+Review date: 2026-08-31
+
+## Scope
+
+- Previous catalog maintenance boundary: 2026-08-27.
+- Search window: 2026-08-13 through 2026-08-31, retaining roughly 14 days of overlap for delayed indexing, repository releases, and product-status changes.
+- Sources checked: official arXiv recent listings and record pages; official GitHub repositories, releases, package metadata, source trees, tests, examples, and licenses; and first-party product pages, release notes, and vendor announcements.
+- Search concepts: computer-aided design/CAD, parametric CAD, B-rep, CSG, sketches and constraints, extrusion and feature histories, engineering drawings, text/image/sketch-to-CAD, CAD generation/editing/reconstruction/understanding/retrieval, CAD agents, CAD/CAM, manufacturing-aware design, executable CAD evaluation, and physics-aware CAD benchmarks.
+- Curation boundary: resources must directly act on editable CAD representations, CAD-native engineering workflows, or CAD-specific evaluation. Generic mesh/3D generation, Blender-only editing, non-AI optimization, PLM-only assistants, and product announcements without a released capability remain outside the catalog.
+
+## Result
+
+The review added two executable CAD-native benchmarks and one independently useful open-source CAD tool. No paper or company-product entry met the threshold for a new catalog item. The final normalized-URL check also repaired two older paper entries that shared a generic ResearchGate homepage.
+
+| Resource class | High-signal candidates reviewed | Added | In-place updates | Deferred or excluded |
+|---|---:|---:|---:|---:|
+| Papers | 6 | 0 | 2 metadata repairs | 4 excluded; 2 already cataloged |
+| Datasets and benchmarks | 3 | 2 | 0 | 1 duplicate mirror |
+| Open-source projects | 8 | 1 | 0 | 1 deferred; 6 excluded |
+| Company products | 8 vendor families | 0 | 0 | 8 unchanged or non-qualifying |
+| **Net README change** | — | **3** | **0** | — |
+
+The README catalog moves from 595 to 598 entries. The historical JSONL registry remains at 638 deduplicated records, including 496 dated 2024–2026, because this weekly increment does not rewrite that separately sourced snapshot.
+
+## Papers
+
+Official arXiv recent listings for `cs.CV`, `cs.AI`, `cs.CE`, `cs.RO`, `cs.GR`, `cs.HC`, `cs.LG`, and `math.OC` were checked with focused CAD and engineering-design terms.
+
+- IterCAD (`2608.24020`) and Design-to-Plan (`2608.24039`) appeared inside the overlap window but were already present, so no duplicate entries were added.
+- Procedura (`2608.26238`) emits editable OpenSCAD programs and machine-checkable mates, but its evaluated scope is primarily articulated 3D-asset generation and mesh-oriented export rather than a CAD-native engineering design or evaluation workflow; excluded under the current boundary.
+- ViSculpt (`2608.24169`) edits arbitrary meshes through Blender rather than editable parametric CAD or B-rep/CSG; excluded.
+- TailorCoPilot (`2608.25462`) targets garment pattern-making interactions and does not establish a direct engineering-CAD contribution; excluded.
+- A recent cable-structure topology-optimization paper was relevant to design optimization but did not present a clear AI or learning contribution; excluded.
+
+### In-Place Metadata Repairs
+
+- **BRepGAT** — Replaced a generic ResearchGate homepage with DOI `10.1093/jcde/qwad106` and restored the publisher-verified authors, journal, and 2023 publication year.
+- **Real-Time Tool-Path Planning Using Deep Learning for Subtractive Manufacturing** — Replaced the same generic ResearchGate homepage with DOI `10.1109/TII.2023.3342474` and restored the IEEE-verified authors, venue, and 2024 publication year.
+
+No new-paper candidate required a version-only or successor update.
+
+## Datasets and Benchmarks
+
+### Added
+
+- **ParamCAD-AgentBench** — Public executable benchmark for long-horizon language agents constructing kernel-valid parametric CAD. The frozen preview contains 2,409 CadQuery/OpenCASCADE-validated models and 4,818 paired abstract/detailed tasks. The 400-model development split exposes oracles; test and challenge source geometry and oracles are withheld. Code is MIT-licensed, while the data has separate research-release terms. Repository validation completed successfully with `python scripts/validate_release.py`. Source: `https://github.com/Fasuiker/ParamCAD-AgentBench`.
+- **ParaEval** — Apache-2.0 evaluation framework for executed Rhino/Grasshopper artifacts across runtime validity, measured geometry, visual judgment, and headless structural solvability. The repository includes runnable CLI entry points, examples, tests, CI, and two sample `.3dm` models. It reports aggregate development results for 2,216 records across 139 prompts, but does not publish those underlying evaluation records; the README entry therefore describes the public evaluation framework rather than claiming a released full corpus. Source: `https://github.com/magnush01/ParaEval`.
+
+### Excluded
+
+- A newly surfaced `CADTestBench` repository was a mirror of the already cataloged official `dimitrismallis/CADTestBench` implementation; excluded as a duplicate.
+
+## Open-Source Projects
+
+GitHub repository searches covered text-to-CAD, parametric CAD, CAD agents/copilots, FreeCAD, CadQuery, build123d, OpenSCAD, MCP, CAD verification, and CAD benchmarks. More than 100 raw results were noisy forks, mirrors, and minimal scaffolds; eight high-signal repositories received source-tree review.
+
+### Added
+
+- **build123d-mcp** — Apache-2.0 MCP server using build123d/OpenCascade to let AI clients iteratively create, render, inspect, measure, repair, and export CAD as STEP, STL, SVG, and DXF. The repository contains a packaged command-line entry point, PyPI release path, CI, source modules, examples, and tests, and is independently useful beyond any single paper. Source: `https://github.com/pzfreo/build123d-mcp`.
+
+### Deferred or Excluded
+
+- **HarnessCAD** — Substantial multi-backend implementation with installation instructions, CLI entry points, source, and tests, but the README's MIT claim was not backed by a root `LICENSE` file or package-license field when inspected. Deferred pending unambiguous repository-level license evidence.
+- **FreeCAD MCP Next** — Public implementation with source and tests, but it identifies itself as derived from the already cataloged `neka-nat/freecad-mcp`; excluded as a successor/fork without a sufficiently distinct catalog role.
+- Recent `text-to-cad`, `CADTestBench`, and similar repositories whose own badges or metadata pointed to already cataloged canonical projects were excluded as mirrors or forks.
+- README-only repositories, empty scaffolds, and projects lacking a usable execution path or inspectable implementation were excluded.
+
+## Company Products
+
+First-party pages and release material were checked for Autodesk/Fusion, Siemens/NX, Dassault Systèmes/SOLIDWORKS, PTC/Creo and Onshape, Ansys/Synopsys, nTop, and AI-native engineering vendors including Backflip.
+
+- Onshape's FeatureScript MCP release, SOLIDWORKS Design AI companions AURA and LEO, and the Backflip Fusion add-in remain publicly described and were already represented accurately in the catalog.
+- Autodesk, Siemens, PTC, Ansys/Synopsys, and nTop did not publish a new qualifying CAD-native capability inside the review window that was both concrete and publicly available, beta, or early access.
+- PLM-only assistants, roadmap language, webinars, generic conversational help, and text/image-to-mesh offerings were not treated as released CAD-product evidence.
+
+No commercial entry needed a status transition or in-place metadata update.
+
+## Deduplication and Validation
+
+- README and `research/papers/*.jsonl` were checked using canonical titles, unversioned arXiv IDs, DOI links, and normalized project URLs before insertion.
+- Each new resource appears once in the most specific section; the benchmark entries are not repeated under tools, and the standalone MCP server is not attached to a paper.
+- All three repository URLs resolve to the canonical public projects. The two pre-existing duplicate generic ResearchGate links were replaced with their distinct primary DOI records, leaving no duplicate normalized URL among catalog entries.
+- `python3 scripts/validate_catalog.py` passes with 598 README entries, 638 deduplicated JSONL records, and 496 JSONL records dated 2024–2026.
+- `git diff --check` passes.

--- a/scripts/validate_catalog.py
+++ b/scripts/validate_catalog.py
@@ -21,7 +21,7 @@ SURVEY_FILES = [
 ]
 
 EXPECTED = {
-    "readme_entries": 595,
+    "readme_entries": 598,
     "jsonl_dedup_records": 638,
     "jsonl_2024_2026_records": 496,
 }


### PR DESCRIPTION
## What this PR does

Adds three high-confidence AI+CAD resources from the 2026-08-13 through 2026-08-31 overlap window, records the four-pool review, and repairs two pre-existing generic publication links.

### Added

- Datasets and benchmarks (2):
  - ParamCAD-AgentBench — executable CadQuery/OpenCASCADE benchmark with 2,409 models and 4,818 paired agent tasks.
  - ParaEval — runnable four-layer evaluation for executed Rhino/Grasshopper parametric designs.
- Open-source tools (1):
  - build123d-mcp — Apache-2.0 MCP server for iterative build123d/OpenCascade modeling, inspection, repair, measurement, and CAD export.
- Papers (0).
- Company products (0).

### In-place updates

- BRepGAT: replaced the shared ResearchGate homepage with DOI `10.1093/jcde/qwad106` and restored publisher-verified authors, venue, and year.
- Real-Time Tool-Path Planning Using Deep Learning for Subtractive Manufacturing: replaced the shared ResearchGate homepage with DOI `10.1109/TII.2023.3342474` and restored IEEE metadata.

### Deferred or excluded

- HarnessCAD deferred because its README's MIT claim was not backed by a root license file or package-license field.
- Procedura, ViSculpt, TailorCoPilot, and a non-AI topology-optimization paper excluded under the CAD-native/AI relevance boundary.
- FreeCAD MCP Next and recent text-to-CAD/CADTestBench mirrors excluded as derivative or duplicate projects.
- Vendor families covering Autodesk, Siemens, SOLIDWORKS, PTC/Onshape, Ansys, nTop, and AI-native products were checked; no new qualifying status transition was found.

### Files changed

- `README.md`
- `AGENTS.md`
- `scripts/validate_catalog.py`
- `research/catalog_audit/catalog_increment_review_2026-08-31.md`

The README catalog count moves from 595 to 598. Historical JSONL counts remain unchanged at 638 deduplicated records and 496 records dated 2024–2026.

## Checklist

- [x] Entries follow the repository format and use source-specific labels
- [x] Placed in the most specific section and sorted newest-first
- [x] Canonical repository and DOI links verified
- [x] No duplicate catalog titles, unversioned arXiv IDs, or normalized URLs
- [x] No legacy `[[Paper](arXiv)]` labels
- [x] `python3 scripts/validate_catalog.py` passes (598 / 638 / 496)
- [x] `git diff --check` passes
- [x] Remote branch tree matches the locally validated tree
